### PR TITLE
fix: status bar / navigation bar color for iOS 15

### DIFF
--- a/magic_pod_demo_app/AppDelegate.swift
+++ b/magic_pod_demo_app/AppDelegate.swift
@@ -16,6 +16,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
 
+        if #available(iOS 15.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = UIColor(red: 84 / 255.0, green: 157 / 255.0, blue: 84 / 255.0, alpha: 1.0)
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+            UINavigationBar.appearance().standardAppearance = appearance
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
+
         window = UIWindow(frame: UIScreen.main.bounds)
 
         if let window = window {


### PR DESCRIPTION
Before this change, the status bar and navigation bar became transparent by default when built on Xcode 13.4.
refs: https://developer.apple.com/forums/thread/682420

Before
<img src="https://user-images.githubusercontent.com/1135016/185772388-fb9ec959-7eef-46b8-8304-7feb3e16b864.png" width="200"/>


After
<img src="https://user-images.githubusercontent.com/1135016/185772395-4e1cb791-5786-4dd7-886c-9c1cf3b2e9a9.png" width="200"/>
